### PR TITLE
Added option `--harassCaptchaMode`

### DIFF
--- a/PixelPlanetBot/BotOptions.cs
+++ b/PixelPlanetBot/BotOptions.cs
@@ -35,5 +35,8 @@ namespace PixelPlanetBot
 
         [Option("brightnessMaskPath", HelpText = "Path to the image for advanced pixel placing order management, URL, local absolute or relative")]
         public string BrightnessMaskImagePath { get; set; }
+
+        [Option('h', "harassCaptchaMode", Default = false, HelpText = "Determines whether app retries to place pixel every 30 seconds after a captcha appears")]
+        public bool HarassMode { get; set; }
     }
 }

--- a/PixelPlanetBot/Program.cs
+++ b/PixelPlanetBot/Program.cs
@@ -517,12 +517,19 @@ namespace PixelPlanetBot
                 logger.LogDebug("ProcessCaptcha(): starting browser");
                 Process.Start(UrlManager.BaseHttpAdress);
             }
-            while (Console.KeyAvailable)
+            if (options.HarassMode)
             {
-                Console.ReadKey(true);
+                Thread.Sleep(TimeSpan.FromSeconds(30));
             }
-            Console.ReadKey(true);
-            logger.LogDebug("ProcessCaptcha(): got keypress");
+            else
+            {
+                while (Console.KeyAvailable)
+                {
+                    Console.ReadKey(true);
+                }
+                Console.ReadKey(true);
+                logger.LogDebug("ProcessCaptcha(): got keypress");
+            }
             logger.ResumeLogging();
             captchaCts?.Cancel();
             captchaCts?.Dispose();


### PR DESCRIPTION
Added possibility to specify a flag `-h` (or `--harassCaptchaMode`)
which enable an automatical retrying to place pixel after server asks
for a captcha.

I found this useful to automatically retry to place pixel after bot faces 
a captcha because i don't need to switch between browsers and 
accorging terminal. Especially you could feel that having several 
instances of bot with different proxies running simultaneously.
I tested a build with this update and bot worked correctly for me.

For now i hardcoded 30 sec as an interval to sleep during processing
captcha, this wasn't my best and i haven't parametrized this point yet 
but it seemed convenient for me :)

Please feel free to change the patch or request a new updates about 
one.